### PR TITLE
Add placeholder live site domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-- '11.0.0'
+- '12.16.2'
 script:
 - set +e
 - npm test
-- npm run build
+- MODE=production npm run build
 - tar -czvf build.tar.gz build
 deploy:
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
-  "name": "@coreui/coreui-free-react-admin-template",
-  "version": "2.0.5",
-  "description": "CoreUI React Open Source Bootstrap 4 Admin Template",
-  "author": "Łukasz Holeczek",
-  "homepage": "https://coreui.io",
-  "copyright": "Copyright 2018 creativeLabs Łukasz Holeczek",
+  "name": "cms-frontend",
+  "version": "0.2.2",
   "license": "MIT",
   "private": true,
+  "homepage": "https://lets-code.local/",
   "repository": {
     "type": "git",
-    "url": "git@github.com:coreui/coreui-free-react-admin-template.git"
+    "url": "git@github.com:joelgtsantos/cms-frontend.git"
   },
   "dependencies": {
     "@coreui/coreui": "2.0.2",
@@ -70,8 +67,5 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "heroku-postbuild": "npm run build"
-  },
-  "bugs": {
-    "url": "https://github.com/coreui/coreui-free-react-admin-template/issues"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="CoreUI for React - Open Source Bootstrap Admin Template">
-    <meta name="author" content="Łukasz Holeczek">
-    <meta name="keyword" content="Bootstrap,Admin,Template,Open,Source,CSS,SCSS,HTML,RWD,Dashboard,React">
-    <title>CoreUI for React</title>
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/src/config.js
+++ b/src/config.js
@@ -1,27 +1,32 @@
-let domainProfile, domainGalatea, domainSao, protocol;
+let apiFQDN, apiPort, protocol, apiRoute;
 
 const SESSION_STORAGE_KEY = 'access_token';
 const PROFILE_STORAGE_KEY = 'profile';
 
-/* if (process.env.MODE === 'production') {
-  domainProfile = 'fa-backend.herokuapp.com';
-  domainGalatea = 'fa-backend.herokuapp.com';
-  protocol = 'https';
-} else { */
-  domainProfile = 'localhost:9000/cmsusers/cmsusers/api/v1';
-  domainGalatea = 'localhost:9000/galatea/galatea/v1';
-  domainSao = 'localhost:9000/sao/sao/v1';
+if (process.env.MODE === 'production') {
+  // -- Cloud edge server
+  // Please do not update these values since the deployment automation relies on them.
   protocol = 'http';
-/* } */
+  apiFQDN = 'lets-code.local';
+  apiPort = '';
+  apiRoute = '/api';
+} else {
+  // -- Vagrant (cms-boxes) emulated edge server
+  // Feel free to change these values for development purposes
+  protocol = 'http';
+  apiFQDN = '192.168.7.11';
+  apiPort = '';
+  apiRoute = '/api';
+}
 
-const CMS_BASE_URI_PROFILE = `${protocol}://${domainProfile}`;
-const CMS_BASE_URI_GALATEA = `${protocol}://${domainGalatea}`;
-const CMS_BASE_URI_SAO = `${protocol}://${domainSao}`;
+const CMS_BASE_URI_PROFILE = `${protocol}://${apiFQDN}${apiPort}${apiRoute}/cmsusers/v1`;
+const CMS_BASE_URI_GALATEA = `${protocol}://${apiFQDN}${apiPort}${apiRoute}/galatea/v1`;
+const CMS_BASE_URI_SAO = `${protocol}://${apiFQDN}${apiPort}${apiRoute}/sao/v1`;
 
 export {
-        CMS_BASE_URI_PROFILE, 
-        CMS_BASE_URI_GALATEA, 
-        CMS_BASE_URI_SAO, 
-        SESSION_STORAGE_KEY, 
-        PROFILE_STORAGE_KEY
-      };
+  CMS_BASE_URI_PROFILE,
+  CMS_BASE_URI_GALATEA,
+  CMS_BASE_URI_SAO,
+  SESSION_STORAGE_KEY,
+  PROFILE_STORAGE_KEY
+};


### PR DESCRIPTION
Now all the request should be done through the api gateway `api`
route, which should look like this `https://<the domain>/api`.
This change takes in account the development environment which
runs on the local environment with a fixed Class C IP address.

The most relevant change in the package.json file is the `homepage`
field which is required by the build scripts, the other ones are
just grooming changes.